### PR TITLE
Enable Firefox for Android Compatability

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -151,23 +151,25 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 })
 
 // register hotkeys
-chrome.commands.onCommand.addListener(async (command) => {
-  console.log('Detected command: ' + command)
-  switch (command) {
-    case 'open_opal_hotkey':
-      await chrome.tabs.update({ url: 'https://bildungsportal.sachsen.de/opal/home/' })
-      await saveClicks(2)
-      break
-    case 'open_owa_hotkey':
-      await chrome.tabs.update({ url: 'https://msx.tu-dresden.de/owa/' })
-      await saveClicks(2)
-      break
-    case 'open_jexam_hotkey':
-      await chrome.tabs.update({ url: 'https://jexam.inf.tu-dresden.de/' })
-      await saveClicks(2)
-      break
-  }
-})
+if (chrome.commands) {
+  chrome.commands.onCommand.addListener(async (command) => {
+    console.log('Detected command: ' + command)
+    switch (command) {
+      case 'open_opal_hotkey':
+        await chrome.tabs.update({ url: 'https://bildungsportal.sachsen.de/opal/home/' })
+        await saveClicks(2)
+        break
+      case 'open_owa_hotkey':
+        await chrome.tabs.update({ url: 'https://msx.tu-dresden.de/owa/' })
+        await saveClicks(2)
+        break
+      case 'open_jexam_hotkey':
+        await chrome.tabs.update({ url: 'https://jexam.inf.tu-dresden.de/' })
+        await saveClicks(2)
+        break
+    }
+  })
+}
 
 // Set icon on startup
 chrome.storage.local.get(['selectedRocketIcon'], async (resp) => {


### PR DESCRIPTION
#### Description
- Fix crash on Firefox Mobile
- (Mobile has no hotkey support and crashes on hotkey creation)

#### References
I created the PR to fix a crash which prevents the extension to work on mobile.

Referenced Issue: #164 

Referenced ToDo from [project-board](https://github.com/orgs/TUfast-TUD/projects/1):

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [x] Tested my changes on Firefox
- [x] Tested my changes on Chromium-Based-Browsers
- [x] Successfully run `npm run test` locally

#### Additional Information
With this change and #165 the extension should be ready for mobile use.
Just enable Firefox Mobile support in the extensions settings on the marketplace, additional build steps are not needed.