### PR TITLE
Add gecko_android key for android support

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -250,7 +250,8 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{7ef41014-4362-4367-9781-0a90f1317f82}"
-    }
+    },
+    "gecko_android":{}
   },
   "commands": {
     "_execute_action": {


### PR DESCRIPTION
### Pull Request

Added gecko_android key to get AMO android builds.

#### References
#164 
#166 
