### PR TITLE
Fix tufast header in opal

### DIFF
--- a/src/contentScripts/other/opal/insertLogo.ts
+++ b/src/contentScripts/other/opal/insertLogo.ts
@@ -77,9 +77,17 @@ async function injectLogo() {
   // Create container div and insert logo
   const div = document.createElement('div')
   div.className = 'tufast-opal-header'
-  div.style.cssText =
-    'display: flex; flex-direction: row; gap: 16px; align-items: center; height: 100%; padding-top: 9px;'
-  pageHeader.appendChild(div)
+  div.style.cssText = 'display: flex; flex-direction: row; gap: 16px; align-items: center; height: 100%;'
+
+  // insert TUfast header between the OPAL logo and the tools
+  const headerFunctions = pageHeader.querySelector('.header-functions')
+  if (headerFunctions && headerFunctions.parentNode === pageHeader) {
+    pageHeader.insertBefore(div, headerFunctions)
+  } else {
+    // Fallback
+    pageHeader.appendChild(div)
+  }
+
   div.appendChild(logo)
 
   // Helper function to maintain button order in header


### PR DESCRIPTION
### Pull Request

#### Description
Opal updated their header, so we should update ours too.

Current Opal Header with TUfast
<img width="1496" height="43" alt="Screenshot Current Opal Header with TUfast" src="https://github.com/user-attachments/assets/c9a1e64a-ed36-4499-b3c9-9a168828bd4a" />

New Opal Header with TUfast
<img width="1496" height="43" alt="Screenshot New Opal Header with TUfast" src="https://github.com/user-attachments/assets/ab2a1a6c-bb51-4d4e-8171-87db5c3739ac" />

Opal Header without TUfast
<img width="1496" height="44" alt="Screenshot Opal Opal Header without TUfast" src="https://github.com/user-attachments/assets/61c1624f-24ab-4565-82d0-e622a9765e97" />

#### References
–

#### Type of change
- [x] Bug fix (non-breaking change which fixes a bug)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that might cause existing functionality to not work as expected)

#### Further info
- [ ] This change requires a documentation update
- [ ] I updated the documentation accordingly, if required
- [x] I commented my code where its useful

#### Testing
We have 1500+ Users. Please test your changes thoroughly.
- [ ] Tested my changes on Firefox
- [ ] Tested my changes on Firefox mobile 
- [x] Tested my changes on a Chromium-Based-Browser
- [x] Successfully run `npm run test` locally

#### Version increase
- [ ] I increased the version number according to [SemVer](https://semver.org/).

#### Additional Information
Quick fix using Copilot.
